### PR TITLE
bungee使用時のオフラインUUID不正＋limit subの実装誤り修正

### DIFF
--- a/src/amata1219/like/command/LikeOperatorCommand.java
+++ b/src/amata1219/like/command/LikeOperatorCommand.java
@@ -190,7 +190,7 @@ public class LikeOperatorCommand implements BukkitCommandExecutor {
 							limitation += operand;
 							break;
 						case "sub":
-							limitation = Math.min(limitation - operand, 0);
+							limitation = Math.max(limitation - operand, 0);
 							break;
 						default:
 							sender.sendMessage(limitDescription.get());

--- a/src/amata1219/like/command/ParserTemplates.java
+++ b/src/amata1219/like/command/ParserTemplates.java
@@ -23,7 +23,7 @@ public class ParserTemplates {
     });
 
     public static final FailableParser<OfflinePlayer> player = str.append(name -> {
-        UUID uuid = UUIDConverter.getUUIDFromNameAsUUID(name, Bukkit.getOnlineMode());
+        UUID uuid = UUIDConverter.getUUIDFromNameAsUUID(name, true); //本来はBungeecord使っているかをチェックすべき。
         return Main.plugin().players.containsKey(uuid) ? success(Bukkit.getOfflinePlayer(uuid)) : error("指定されたプレイヤーは存在しません。");
     });
 


### PR DESCRIPTION
こた鯖デベロッパーのMellnasと申します。
Likeプラグインにて不具合があったため、暫定で手を打っております。
UUID取得に関して、挙動が変わってしまったのが影響と思っております。
正しく動作することは確認しておりますが、Bungee未使用の環境だとどうなるかわからないため、暫定対応とさせていただいております。
よろしくおねがいします。